### PR TITLE
Fix config to correctly handle dynamic PPID and path

### DIFF
--- a/napalm_logs/config/eos/PROCESS_STARTED.yml
+++ b/napalm_logs/config/eos/PROCESS_STARTED.yml
@@ -7,7 +7,9 @@ messages:
     values:
       agent: ([\w-]+)
       pid|int: (\d+)
-    line: ": '{agent}' starting with PID={pid} (PPID=2030) -- execing '/usr/bin/Bgp'"
+      ppid|int: (\d+)
+      path: ([\w\:\-\/]+)
+    line: ": '{agent}' starting with PID={pid} (PPID={ppid}) -- execing '{path}'"
     model: NO_MODEL
     mapping:
       variables:


### PR DESCRIPTION
The previous eos process_started config had hardcoded values for PPID and the executable path.